### PR TITLE
checks/no_wip: change wip checks to single check with to_lowercase

### DIFF
--- a/src/checks/no_wip.rs
+++ b/src/checks/no_wip.rs
@@ -28,7 +28,7 @@ impl Check for NoWip {
 
     fn verify(&self, checks: &Checks, commit_data: &CommitData) -> Result<()> {
         if let Some(no_wip) = checks.no_wip {
-            if no_wip && commit_data.summary.starts_with("wip") ||  commit_data.summary.starts_with("WIP") {
+            if no_wip && commit_data.summary.to_lowercase().starts_with("wip") {
                 return Err("WIP commits must be finished before merging".into());
             }
         }


### PR DESCRIPTION
Currently we're checking the string twice for the summary starting
with either `WIP` or `wip`, this changes these into one check by
calling `to_lowercase()` from the `std::string::String` library.