### PR TITLE
github: accept both Ok and Created status

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -153,7 +153,8 @@ pub trait TryExecute: Executor {
         }
 
         match self.execute::<serde_json::Value>() {
-            Ok((_, StatusCode::Ok, Some(response))) => {
+            Ok((_, StatusCode::Ok, Some(response))) |
+            Ok((_, StatusCode::Created, Some(response))) => {
                 serde_json::from_value(response).chain_err(|| "Failed to parse response")
             }
             Ok((_, _, Some(response))) => {


### PR DESCRIPTION
The previous commit only accepted Ok, which erroneously failed when
creating a status.