### PR TITLE
docs: update personal access token scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ After cloning the repository, Tailor can be built and run with `cargo run`. The 
 
 ### Configuring GitHub ###
 
-Tailor is designed to be used as a webhook. Each GitHub repository will need to be configured with a new webhook with the payload URL `http://url-of-tailor-instance/hook`, the content type set to `application/json`, and just the "Pull request" event. The token that is given to Tailor will only need to have the `repo:status` scope.
+Tailor is designed to be used as a webhook. Each GitHub repository will need to be configured with a new webhook with the payload URL `http://url-of-tailor-instance/hook`, the content type set to `application/json`, and just the "Pull request" event. The token that is given to Tailor will only need to have the `repo` scope so that it may set statuses and access collaborators.


### PR DESCRIPTION
Turns out, "repo" is required in order to read collaborator information.