### PR TITLE
github: parse title and description from commit 

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The root context is the initial input (a dictionary) into the rule expression. I
       .date
       .github_login
     .message
+    .title
+    .description
   .comments[]
     .user
       .login

--- a/src/expr/ast/mod.rs
+++ b/src/expr/ast/mod.rs
@@ -279,7 +279,10 @@ mod test {
         );
         assert_eq!(
             value(r#""^[A-Za-z\":\\]{,100}$""#),
-            IResult::Done("", Expr::Value(Value::String(r#"^[A-Za-z":\]{,100}$"#.to_string())))
+            IResult::Done(
+                "",
+                Expr::Value(Value::String(r#"^[A-Za-z":\]{,100}$"#.to_string())),
+            )
         );
     }
 

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -35,7 +35,7 @@ pub struct Comment {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Deserialize)]
 pub struct Commit {
     pub sha: String,
     pub commit: CommitBody,
@@ -43,7 +43,7 @@ pub struct Commit {
     pub committer: User,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Deserialize)]
 pub struct CommitBody {
     pub author: Author,
     pub committer: Author,


### PR DESCRIPTION
This allows rules to use title and description without needing to write
complex regular expressions to perform the same operation.