### PR TITLE
expr: add support for lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,17 @@ Each of the list manipulation operators (except `length`), accepts an expression
 |   `map`  |    List   | Expression |   List  | List the result of each elements expression                     |
 | `length` |    List   |            | Numeral | The number of elements in the list                              |
 
-###### Miscellaneous ######
+###### String Manipulation ######
 
 | Operator |   Input   |  Argument  |  Result |                           Description                           |
 |:--------:|:---------:|:----------:|:-------:|:----------------------------------------------------------------|
 |  `test`  |   String  |   String   | Boolean | `true` if the argument (a regular expression) matches the input |
+| `lines`  |   String  |            |  List   | Splits a string by newlines into a list of strings              |
+
+###### Miscellaneous ######
+
+| Operator |   Input   |  Argument  |  Result |                           Description                           |
+|:--------:|:---------:|:----------:|:-------:|:----------------------------------------------------------------|
 |    `.`   |           |            |  Value  | The current context                                             |
 
 ##### Values #####

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ rules:
 
     # The expression describes the rule itself. Refer to the language
     # documentation for an overview of the available functionality.
-    expression:  .commits all(.message test "^.{0,50}$")
+    expression:  .commits all(.title length < 51)
 ```
 
 Each of the rules are run on the entire pull request (the [root context](README.md#root-context)). They are run independently and cannot influence one another. Often times, it is useful to use `.commits all` to run an expression on each of the commits in the pull request, requiring all of them to comply. This is detailed further in the [Expressions section](README.md#expressions). The rule expression must result in a boolean value, `true` indicating a success and `false` a failure.
@@ -39,7 +39,7 @@ It might be helpful to break down a few examples.
 
 This expression returns `true` if there are exactly ten commits in the pull request: `.commits length = 10`. Parenthesis around every operation could be added for clarity: `(((.commits) length) = 10)`
 
-This expression returns `true` if every commit message is no more than fifty characters: `.commits all(.message test "^.{0,50}$")`. This expression makes use of the `all` operator, which is used for manipulating lists. For every commit, the expression `.message test "^.{0,50}$"` is evaluated with the context set to the commit in question. This inner expression then uses a context specifier (`.message`) to get the commit message and uses `test` to see if there are more than fifty characters. If every one of the inner expressions evaluates to `true`, `all` also results in `true`.
+This expression returns `true` if every commit message is no more than fifty characters: `.commits all(.title length < 51)`. This expression makes use of the `all` operator, which is used for manipulating lists. For every commit, the expression `.title length < 51` is evaluated with the context set to the commit in question. This inner expression then uses a context specifier (`.title`) to get the commit title and uses `length` to get the length of the title and compares to see if there are more than fifty characters. If every one of the inner expressions evaluates to `true`, `all` also results in `true`.
 
 There are a handful of other operators, detailed below.
 

--- a/src/expr/ast/mod.rs
+++ b/src/expr/ast/mod.rs
@@ -37,6 +37,7 @@ enum PartialOperation {
     Length,
 
     Test(Expr),
+    Lines,
 }
 
 #[derive(PartialEq)]
@@ -131,7 +132,8 @@ named!(value <&str, Expr>, ws!(
 named!(operation0 <&str, PartialOperation>, ws!(
     alt!(
         tag!("not")    => { |_| PartialOperation::Not    } |
-        tag!("length") => { |_| PartialOperation::Length }
+        tag!("length") => { |_| PartialOperation::Length } |
+        tag!("lines")  => { |_| PartialOperation::Lines  }
     )
 ));
 
@@ -197,6 +199,7 @@ named!(expr <&str, Expr>, ws!(
                     PartialOperation::Length      => Expr::Operation(Operation::Length(Box::new(ast))),
 
                     PartialOperation::Test(arg) => Expr::Operation(Operation::Test(Box::new(ast), Box::new(arg))),
+                    PartialOperation::Lines     => Expr::Operation(Operation::Lines(Box::new(ast))),
                 }
             }
         ) >>

--- a/src/expr/ast/types.rs
+++ b/src/expr/ast/types.rs
@@ -33,6 +33,8 @@ pub enum Operation {
     Length(Box<Expr>),
 
     Test(Box<Expr>, Box<Expr>),
+    Lines(Box<Expr>),
+
     Context(String),
 }
 

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -142,6 +142,14 @@ fn eval_expr(expr: Expr, context: &Value) -> Result<Value> {
                     .is_match(&expr!(*term, context, Value::String)),
             ))
         }
+        Expr::Operation(Operation::Lines(a)) => {
+            Ok(Value::List(
+                expr!(*a, context, Value::String)
+                    .lines()
+                    .map(|s| Expr::Value(Value::String(s.into())))
+                    .collect::<Vec<_>>(),
+            ))
+        }
         Expr::Operation(Operation::Context(path)) => {
             let mut context = context;
             for elem in path.split('.') {

--- a/src/github/validate.rs
+++ b/src/github/validate.rs
@@ -183,7 +183,7 @@ fn fetch_pull_request(
                         .into(),
                     ),
                 }
-                let description = lines.fold(String::new(), |lines, line| lines + line);
+                let description = lines.collect::<Vec<_>>().as_slice().join("\n");
                 (title, description)
             };
 


### PR DESCRIPTION
The lines function splits a string into a list of strings, separated by
newlines.