### PR TITLE
github: remove support for commit message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tailor"
 version = "0.1.0"
-authors = ["Alex Crawford <alex.crawford@coreos.com>", "Alexander Pavel <alex.pavel@coreos.com>"]
+authors = ["Alex Crawford <alex.crawford@coreos.com>"]
 
 [dependencies]
 base64 = "*"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It might be helpful to break down a few examples.
 
 This expression returns `true` if there are exactly ten commits in the pull request: `.commits length = 10`. Parenthesis around every operation could be added for clarity: `(((.commits) length) = 10)`
 
-This expression returns `true` if every commit message is no more than fifty characters: `.commits all(.title length < 51)`. This expression makes use of the `all` operator, which is used for manipulating lists. For every commit, the expression `.title length < 51` is evaluated with the context set to the commit in question. This inner expression then uses a context specifier (`.title`) to get the commit title and uses `length` to get the length of the title and compares to see if there are more than fifty characters. If every one of the inner expressions evaluates to `true`, `all` also results in `true`.
+This expression returns `true` if every commit title is no more than fifty characters: `.commits all(.title length < 51)`. This expression makes use of the `all` operator, which is used for manipulating lists. For every commit, the expression `.title length < 51` is evaluated with the context set to the commit in question. This inner expression then uses a context specifier (`.title`) to get the commit title and uses `length` to get the length of the title and compares to see if there are more than fifty characters. If every one of the inner expressions evaluates to `true`, `all` also results in `true`.
 
 There are a handful of other operators, detailed below.
 
@@ -119,7 +119,6 @@ The root context is the initial input (a dictionary) into the rule expression. I
       .email
       .date
       .github_login
-    .message
     .title
     .description
   .comments[]

--- a/src/github/validate.rs
+++ b/src/github/validate.rs
@@ -40,7 +40,6 @@ struct Commit {
     sha: String,
     author: types::Author,
     committer: types::Author,
-    message: String,
     title: String,
     description: String,
 }
@@ -201,7 +200,6 @@ fn fetch_pull_request(
                     date: c.commit.committer.date,
                     github_login: Some(c.committer.login),
                 },
-                message: c.commit.message,
                 title,
                 description,
             })


### PR DESCRIPTION
This has been replaced by the commit title and commit description
instead.