### PR TITLE
src/github/validate: include input in failure message

### DIFF
--- a/src/github/validate.rs
+++ b/src/github/validate.rs
@@ -65,7 +65,7 @@ pub fn pull_request(job: &worker::PullRequestJob, client: &Github) -> Result<Vec
         })?;
 
         if !result {
-            failures.push(format!("Failed {} ({})", rule.name, rule.description))
+            failures.push(format!("Failed {} ({}) on {}", rule.name, rule.description, input))
         }
     }
     Ok(failures)


### PR DESCRIPTION
Includes the input string in failure messages so that users can know
which commit caused tailor to fail.

Untested.