### PR TITLE
github: expose base and head of pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ The root context is the initial input (a dictionary) into the rule expression. I
       .login
     .body
     .created_at
+  .base
+    .sha
+    .label
+    .user
+      .login
+  .head
+    .sha
+    .label
+    .user
+      .login
 ```
 
 ### Admin Commands ###

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -50,9 +50,10 @@ pub struct CommitBody {
     pub message: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Value)]
 pub struct CommitReference {
     pub sha: String,
+    pub label: String,
     pub user: User,
 }
 
@@ -100,6 +101,7 @@ pub struct PullRequest {
     pub number: usize,
     pub title: String,
     pub body: Option<String>,
+    pub base: CommitReference,
     pub head: CommitReference,
 }
 

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -15,7 +15,7 @@
 use chrono::prelude::*;
 use expr::ast::Value;
 
-#[derive(Clone, Deserialize, Value)]
+#[derive(Deserialize, Value)]
 pub struct Author {
     pub name: String,
     pub email: String,
@@ -28,7 +28,7 @@ pub struct Collaborator {
     pub permission: Permission,
 }
 
-#[derive(Clone, Deserialize, Value)]
+#[derive(Deserialize, Value)]
 pub struct Comment {
     pub user: User,
     pub body: String,
@@ -109,7 +109,7 @@ pub struct Repository {
     pub name: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Value)]
+#[derive(Debug, Deserialize, Value)]
 pub struct User {
     pub login: String,
 }

--- a/src/github/validate.rs
+++ b/src/github/validate.rs
@@ -23,7 +23,7 @@ use github::types;
 use serde_yaml;
 use worker;
 
-#[derive(Clone, Value)]
+#[derive(Value)]
 struct PullRequest {
     user: types::User,
     title: String,
@@ -34,7 +34,7 @@ struct PullRequest {
     #[value(hidden)] head_sha: String,
 }
 
-#[derive(Clone, Value)]
+#[derive(Value)]
 struct Commit {
     sha: String,
     author: types::Author,
@@ -49,7 +49,7 @@ pub fn pull_request(job: &worker::PullRequestJob, client: &Github) -> Result<Vec
     let exemptions = find_exemptions(client, &job.owner, &job.repo, &pr)?;
 
     let mut failures = Vec::new();
-    let input = pr.clone().into();
+    let input = pr.into();
     for rule in repo.rules
         .iter()
         .filter(|rule| !exemptions.contains(&rule.name))

--- a/src/github/validate.rs
+++ b/src/github/validate.rs
@@ -30,8 +30,8 @@ struct PullRequest {
     body: Option<String>,
     commits: Vec<Commit>,
     comments: Vec<types::Comment>,
-
-    #[value(hidden)] head_sha: String,
+    base: types::CommitReference,
+    head: types::CommitReference,
 }
 
 #[derive(Value)]
@@ -84,7 +84,7 @@ fn fetch_repo_config(
         .repo(repo)
         .contents()
         .path(".github/tailor.yaml")
-        .reference(&pr.head_sha)
+        .reference(&pr.head.sha)
         .try_execute()
         .chain_err(|| {
             format!("Failed to fetch repo configuration for {}/{}", owner, repo)
@@ -220,7 +220,8 @@ fn fetch_pull_request(
         user: pr.user,
         title: pr.title,
         body: pr.body,
-        head_sha: pr.head.sha,
+        base: pr.base,
+        head: pr.head,
         commits,
         comments,
     })


### PR DESCRIPTION
This allows expressions to reference the base and head commits of a pull
request, including the branch label.

Fixes #46.

/cc @stepanstipl 